### PR TITLE
Add --accept-terms-of-use to commandArgs

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -56,6 +56,7 @@ prysm:
       - "/data/"
       - "--jwt-secret=/secret/jwt.hex"
       - "--execution-endpoint=http://geth.default.svc.cluster.local:8551"
+      - "--accept-terms-of-use"
     podAnnotations: {}
     podSecurityContext: {}
     securityContext: {}


### PR DESCRIPTION
We use the flag `--accept-terms-of-use` to automatically start the pod without interactively accepting the license.

```
Prysmatic Labs Terms of Use

By downloading, accessing or using the Prysm implementation (“Prysm”), you (referenced herein
as “you” or the “user”) certify that you have read and agreed to the terms and conditions below.

TERMS AND CONDITIONS: https://github.com/prysmaticlabs/prysm/blob/master/TERMS_OF_SERVICE.md


Type "accept" to accept this terms and conditions [accept/decline]: (default: decline):
time="2024-02-26 08:19:14" level=error msg="could not scan text input, if you are trying to run in non-interactive environment, you
can use the --accept-terms-of-use flag after reading the terms and conditions here: 
https://github.com/prysmaticlabs/prysm/blob/master/TERMS_OF_SERVICE.md" prefix=main
```